### PR TITLE
chore: Update axios baseURL to production endpoint

### DIFF
--- a/src/redux/auth/authOperations.js
+++ b/src/redux/auth/authOperations.js
@@ -2,7 +2,9 @@ import { createAsyncThunk } from "@reduxjs/toolkit";
 import axios from "../axiosInstance";
 import { authService } from "../../services/authService";
 
-axios.defaults.baseURL = "http://localhost:3000";
+// axios.defaults.baseURL = "http://localhost:3000";
+axios.defaults.baseURL = "https://taskpro-backend-65h4.onrender.com";
+
 
 export const registerThunk = createAsyncThunk(
   "auth/register",

--- a/src/redux/axiosInstance.js
+++ b/src/redux/axiosInstance.js
@@ -1,7 +1,8 @@
 import axios from "axios";
 
 const instance = axios.create({
-  baseURL: "http://localhost:3000",
+  // baseURL: "http://localhost:3000",
+  baseURL: "https://taskpro-backend-65h4.onrender.com",
 });
 
 instance.interceptors.request.use(

--- a/src/services/axios.js
+++ b/src/services/axios.js
@@ -1,6 +1,7 @@
 import axios from "axios";
 
-export const BASE_URL = "http://localhost:3000";
+// export const BASE_URL = "http://localhost:3000";
+export const BASE_URL = "https://taskpro-backend-65h4.onrender.com";
 
 const instance = axios.create({
   baseURL: BASE_URL,


### PR DESCRIPTION
- Changed axios instance and auth operations to use the production baseURL: https://taskpro-backend-65h4.onrender.com.
- Commented out the previous localhost baseURL for clarity.